### PR TITLE
fix(llm): rewrite prompts for expert judgment and fix release group API fallback

### DIFF
--- a/src/chart_binder/llm/adjudicator.py
+++ b/src/chart_binder/llm/adjudicator.py
@@ -59,48 +59,28 @@ class AdjudicationResult:
     response_json: str = ""
 
 
-SYSTEM_PROMPT_V1 = """You are a music metadata expert specialized in determining the canonical release for recordings.
+SYSTEM_PROMPT_V1 = """\
+You are a music metadata expert. An automated system could not determine the \
+canonical release for a recording and is asking for your judgment.
 
-Your task is to analyze evidence about a recording and determine:
-1. The Canonical Release Group (CRG): The authoritative release group where this recording first appeared
-2. The Representative Release (RR): The specific release within the CRG to use for metadata
+Given the evidence about a recording, determine:
+- Canonical Release Group (CRG): The release group where this recording first \
+appeared as an official release
+- Representative Release (RR): A specific release within that group (prefer \
+artist's origin country if known, otherwise earliest)
 
-CRITICAL DECISION RULES (apply in order):
+Use your music knowledge to make the best determination from the evidence provided.
 
-1. **Compilations are never canonical** - Exclude any release group with "Secondary: Compilation"
-
-2. **Lead Single Window Rule (90 days)**:
-   - If the earliest single/EP is within 90 days BEFORE an album, choose the ALBUM as CRG
-   - Only if the single is >90 days before the album should you choose the single
-   - Example: Single Oct 1974, Album Nov 1 1974 = ~30 days = Choose ALBUM
-
-3. **Soundtrack Exception**: If the recording was created specifically for a soundtrack, the soundtrack is CRG
-
-4. **Live vs Studio**: Live recordings are only CRG if no studio version exists
-
-5. **Remixes**: Link to the original single/EP release, not remix compilations
-
-6. **Representative Release Selection**:
-   - Within the chosen CRG, select the specific release (RR)
-   - PREFER releases from the artist's origin country (check "Origin Country" field)
-   - If origin country unavailable, prefer earliest release in the CRG
-
-REASONING PROCESS:
-Step 1: Eliminate all compilations
-Step 2: Identify earliest single/EP and earliest album dates
-Step 3: Calculate days between them - if ≤90 days, prefer album
-Step 4: Within chosen CRG, find releases matching origin country
-Step 5: State your confidence (0.0-1.0)
-
-You must respond in valid JSON format with these exact fields:
+Respond in valid JSON:
 {
-  "crg_mbid": "the release group MBID you selected",
-  "rr_mbid": "the release MBID you selected within the CRG",
+  "crg_mbid": "the release group ID you selected",
+  "rr_mbid": "the release ID within the CRG",
   "confidence": 0.0 to 1.0,
   "rationale": "concise one-line explanation"
 }
 
-If you cannot determine the canonical release with reasonable confidence, set confidence below 0.60 and explain why."""
+If you cannot determine the answer with reasonable confidence, set confidence \
+below 0.60 and explain why."""
 
 
 class LLMAdjudicator:

--- a/src/chart_binder/llm/langchain_callbacks.py
+++ b/src/chart_binder/llm/langchain_callbacks.py
@@ -79,7 +79,9 @@ class LLMLoggingCallback(BaseCallbackHandler):
                 flat_messages.append(
                     {
                         "role": msg.type,
-                        "content": msg_content if isinstance(msg_content, str) else str(msg_content),
+                        "content": msg_content
+                        if isinstance(msg_content, str)
+                        else str(msg_content),
                     }
                 )
 

--- a/src/chart_binder/llm/llm_logger.py
+++ b/src/chart_binder/llm/llm_logger.py
@@ -230,9 +230,7 @@ def test_llm_logger_with_tool_calls(tmp_path: Path) -> None:
         tokens_used=50,
         finish_reason="tool_calls",
         duration_seconds=2.0,
-        tool_calls=[
-            {"id": "call_1", "name": "search_artist", "arguments": {"query": "Beatles"}}
-        ],
+        tool_calls=[{"id": "call_1", "name": "search_artist", "arguments": {"query": "Beatles"}}],
     )
     logger.log(entry)
 

--- a/src/chart_binder/llm/tools.py
+++ b/src/chart_binder/llm/tools.py
@@ -90,19 +90,19 @@ def search_artist(query: str) -> str:
             return _json_response(
                 "no_results",
                 query=query,
-                action="Try a different spelling or use web_search for more context",
+                action="Proceed with available evidence",
             )
 
         return _json_response(
             "success",
             content=response.to_context_string(),
             count=response.total_count,
-            action="Use get_artist with an MBID to get detailed info",
+            action="Use this information in your analysis",
         )
 
     except Exception as e:
         log.error("Artist search error: %s", e)
-        return _json_response("error", error=str(e), action="Try again or use web_search")
+        return _json_response("error", error=str(e), action="Proceed with available evidence")
 
 
 @tool
@@ -174,14 +174,14 @@ def search_recording(title: str, artist: str | None = None) -> str:
                 "no_results",
                 title=title,
                 artist=artist,
-                action="Try searching with different spelling or without artist filter",
+                action="Proceed with available evidence",
             )
 
         return _json_response(
             "success",
             content=response.to_context_string(),
             count=response.total_count,
-            action="Use get_recording with an MBID for details, or search_release_group to find albums",
+            action="Analyze these results and make your decision",
         )
 
     except Exception as e:
@@ -259,14 +259,14 @@ def search_release_group(title: str, artist: str | None = None) -> str:
                 "no_results",
                 title=title,
                 artist=artist,
-                action="Try different spelling or use web_search for more context",
+                action="Proceed with available evidence",
             )
 
         return _json_response(
             "success",
             content=response.to_context_string(),
             count=response.total_count,
-            action="Use get_release_group for details or get_releases_in_group to see all releases",
+            action="Analyze these results and make your decision",
         )
 
     except Exception as e:
@@ -307,7 +307,7 @@ def get_release_group(mbid: str) -> str:
         return _json_response(
             "success",
             content=response.to_context_string(),
-            action="Use get_releases_in_group to see individual releases in this group",
+            action="Use this information to make your decision",
         )
 
     except Exception as e:
@@ -350,7 +350,7 @@ def get_releases_in_group(rg_mbid: str) -> str:
             "success",
             content=response.to_context_string(),
             count=response.total_count,
-            action="Select the representative release - prefer earliest in artist's origin country",
+            action="Select the representative release and make your decision",
         )
 
     except Exception as e:
@@ -387,7 +387,7 @@ def web_search(query: str) -> str:
             return _json_response(
                 "no_results",
                 query=query,
-                action="Try different search terms",
+                action="Proceed with available evidence",
             )
 
         # Format results
@@ -406,7 +406,7 @@ def web_search(query: str) -> str:
             "success",
             content="\n".join(lines),
             count=len(response.results),
-            action="Use web_fetch to get more details from a specific URL",
+            action="Use these results in your analysis",
         )
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- Fixes #61: LLM agent hits recursion limit by looping on tool calls
- Rewrites adjudication prompts to frame LLM as expert consultant (no rules re-execution)
- Fixes `get_releases_in_group` bug: adds MusicBrainz browse API fallback for MBIDs not in local DB
- Adds deduplication guard to prevent infinite tool-calling loops

## Changes
- `adjudicator.py`: Strip rules from `SYSTEM_PROMPT_V1`, frame as expert judgment
- `agent_adjudicator.py`: Rewrite `AGENT_SYSTEM_PROMPT` — mandatory text-before-tools, no decision rules
- `agent_adjudicator.py`: Add deduplication + no_results tracking in `_run_simple_agent`
- `agent_adjudicator.py`: Remove prescriptive timeline interpretations from evidence prompt
- `agent_adjudicator.py`: Reduce `MAX_AGENT_ITERATIONS` from 15 to 5
- `tools.py`: Change tool response `action` fields to "proceed with evidence" instead of encouraging retries
- `search_tool.py`: Add MB API fallback in `get_release_group_releases`
- `musicbrainz.py`: Add `browse_releases_by_release_group` (async + sync wrapper)

## Root Cause
Two issues combined to create the loop:
1. **Prompt**: Re-stated the same rules the deterministic engine already checked, causing the model to treat tool-calling as its primary action instead of analyzing evidence
2. **Bug**: `get_releases_in_group` only checked local DB (Discogs IDs like `discogs-master-62649`) and returned `no_results` for MusicBrainz UUIDs (like `a83637bf-...`) found via the search API

## Test plan
- [x] `uv run python devtools/lint.py` passes (0 errors)
- [x] `uv run pytest` passes (262 passed, 5 skipped)
- [ ] Manual test: `uv run canon --log decide` on the U2 file from the issue
- [ ] Verify agent produces text reasoning before any tool calls
- [ ] Verify `get_releases_in_group` returns results for MB UUIDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)